### PR TITLE
UI components migration

### DIFF
--- a/src/components/Chat/MainWindow/ContentHeader.jsx
+++ b/src/components/Chat/MainWindow/ContentHeader.jsx
@@ -5,7 +5,7 @@ import { useContext, useEffect, useState } from "react";
 import { GeneralContextProvider } from "../../ContextProviders/GeneralContextProvider.jsx";
 import { toSvg } from "jdenticon";
 import Box from "@mui/material/Box";
-import {ImageListItem, Typography} from "@mui/material";
+import {Button, Dialog, DialogTitle, IconButton, ImageListItem, Input, Typography} from "@mui/material";
 import {
     ContentHeaderContainerBoxStyle,
     DetailsContainerBoxStyle,
@@ -15,10 +15,19 @@ import {
     ImageContainerBoxStyle,
     ImageContainerImageStyle
 } from "./ContentHeader.styles.js";
+import {
+    CloseButtonContainerButtonStyle,
+    ModalButtonsContainerBoxStyle,
+    ModalContainerDialogStyle,
+    ModalContentContainerBoxStyle, ModalInputContainerInputStyle,
+    ModalTitleContainerDialogTitleStyle, SendButtonContainerButtonStyle
+} from "../SidePanel/Header.styles.js";
 
 const ContentHeader = () => {
     const { selectedPeer } = useContext(GeneralContextProvider);
     const [ peerImage, setPeerImage] = useState();
+    const [openModal, setOpenModal] = useState(false);
+    const [newAlias, setNewAlias] = useState("");
     
     // Dynamically create peer image
     useEffect(() => {
@@ -29,7 +38,45 @@ const ContentHeader = () => {
         setPeerImage(imageDataUrl);
     }, [selectedPeer])
 
+
+    const openModalHandler = () => {
+        setOpenModal(true);
+    };
+    const closeModalHandler = () => {
+        setOpenModal(false);
+        setNewAlias("");
+
+    };
+    const saveAliasHandler = () => {
+        if (newAlias) {
+            try{
+                localStorage.setItem(selectedPeer, newAlias);
+                console.log(`Alias salvato: ${newAlias}`);
+                setNewAlias("");
+
+
+            }
+            catch(error) {
+                console.error(error);
+            }
+        }
+        else {
+            alert("Alias can't be empty")
+        }
+        closeModalHandler();
+    }
+    const checkifAlias = () => {
+        return localStorage.getItem(selectedPeer) !== null;
+    };
+    const retrieveAliasHandler = () => {
+        if(checkifAlias()){
+            return localStorage.getItem(selectedPeer)
+        }
+        return selectedPeer
+    }
+
     return(
+        <>
         <Box
              sx={ContentHeaderContainerBoxStyle}>
                 <Box
@@ -44,7 +91,7 @@ const ContentHeader = () => {
                     sx={DetailsContainerBoxStyle}>
                     <Typography component={"span"}
                                 sx={DetailsTitleContainerTypographyStyle}
-                    >{selectedPeer}</Typography>
+                    >{retrieveAliasHandler()}</Typography>
                     <Typography component={"span"}
                                 sx={DetailsSpanContainerTypographyStyle}
                                 >last seen 10 minutes ago</Typography>
@@ -52,9 +99,65 @@ const ContentHeader = () => {
                 <Box
                      sx={IconsContainerBoxStyle}>
                     <FontAwesomeIcon icon={faSearch} />
-                    <FontAwesomeIcon icon={faEllipsisV}/>
+                    <IconButton onClick={openModalHandler}>
+                        <FontAwesomeIcon icon={faEllipsisV}/>
+                    </IconButton>
                 </Box>
         </Box>
+            <Dialog open={openModal}
+                    onClose={closeModalHandler}
+                    slotProps={{
+                        backdrop: {
+                            sx: {
+                                backgroundColor: 'rgba(0, 0, 0, 0.25)',
+                            },
+                        },
+
+                    }}
+
+                    sx={ModalContainerDialogStyle}>
+                <Box  sx={ModalContentContainerBoxStyle} >
+                    <DialogTitle sx={ModalTitleContainerDialogTitleStyle}>Save Address</DialogTitle>
+
+                    <Box>
+                        <label>Address</label>
+                        <Input
+                            type="text"
+                            value={selectedPeer}
+                            disabled={true}
+                            sx={ModalInputContainerInputStyle}
+                            disableUnderline={true}
+                        />
+                    </Box>
+                    <Box>
+                        <label>New Alias:</label>
+                        <Input
+                            type="text"
+                            id="newAlias"
+                            value={newAlias}
+                            onChange={(event) => setNewAlias(event.target.value)}
+                            placeholder="Enter Alias for the address"
+                            sx={ModalInputContainerInputStyle}
+                            disableUnderline={true}
+                        />
+                    </Box>
+
+                    <Box sx={ModalButtonsContainerBoxStyle} >
+                        <Button
+                            onClick={() => {saveAliasHandler()}}
+
+                            sx={SendButtonContainerButtonStyle}>
+
+                            Save
+                        </Button>
+                        <Button onClick={closeModalHandler}
+                                sx={CloseButtonContainerButtonStyle}>
+                            Cancel
+                        </Button>
+                    </Box>
+                </Box>
+            </Dialog>
+        </>
     )
 }
 

--- a/src/components/Chat/MainWindow/ContentHeader.jsx
+++ b/src/components/Chat/MainWindow/ContentHeader.jsx
@@ -49,31 +49,42 @@ const ContentHeader = () => {
     };
     const saveAliasHandler = () => {
         if (newAlias) {
-            try{
-                localStorage.setItem(selectedPeer, newAlias);
-                console.log(`Alias salvato: ${newAlias}`);
+            try {
+                let contacts = JSON.parse(localStorage.getItem("Contacts"));
+                if (contacts) {
+                    contacts[selectedPeer] = newAlias;
+                } else {
+                    contacts = { [selectedPeer]: newAlias };
+                }
+
+                localStorage.setItem('Contacts', JSON.stringify(contacts));
+
                 setNewAlias("");
 
+            } catch (error) {
+                console.error("Errore durante il salvataggio dei contatti:", error);
+            }
+        } else {
+            alert("Alias can't be empty");
+        }
 
-            }
-            catch(error) {
-                console.error(error);
-            }
-        }
-        else {
-            alert("Alias can't be empty")
-        }
+
         closeModalHandler();
     }
     const checkifAlias = () => {
-        return localStorage.getItem(selectedPeer) !== null;
-    };
-    const retrieveAliasHandler = () => {
-        if(checkifAlias()){
-            return localStorage.getItem(selectedPeer)
+        if (localStorage.getItem("Contacts") !== null){
+
+            let contacts = JSON.parse(localStorage.getItem("Contacts"));
+
+            if (contacts[selectedPeer] !== null && contacts[selectedPeer] !== "" && contacts[selectedPeer] !== undefined){
+                return contacts[selectedPeer]
+            }
+
         }
         return selectedPeer
-    }
+
+    };
+
 
     return(
         <>
@@ -91,7 +102,7 @@ const ContentHeader = () => {
                     sx={DetailsContainerBoxStyle}>
                     <Typography component={"span"}
                                 sx={DetailsTitleContainerTypographyStyle}
-                    >{retrieveAliasHandler()}</Typography>
+                    >{checkifAlias()}</Typography>
                     <Typography component={"span"}
                                 sx={DetailsSpanContainerTypographyStyle}
                                 >last seen 10 minutes ago</Typography>

--- a/src/components/Chat/MainWindow/SendMessageBox.jsx
+++ b/src/components/Chat/MainWindow/SendMessageBox.jsx
@@ -5,7 +5,7 @@ import { GeneralContextProvider} from "../../ContextProviders/GeneralContextProv
 import { sendTransaction } from "../../../utils/sendTransaction.js";
 import { encryptMessage } from "../../../utils/e2ee.js";
 import Box from "@mui/material/Box";
-import {Button, IconButton, styled} from "@mui/material";
+import {Button, IconButton, Input, styled} from "@mui/material";
 import { keyframes } from '@emotion/react';
 import {
     EmojiButtonContainerBoxStyle,
@@ -13,7 +13,7 @@ import {
     IsSendingMessageIconHiddenContainerIconButtonStyle,
     IsSendingMessageIconVisibleContainerIconButtonStyle,
     MessageBoxContainerBoxStyle,
-    MessageContentContainerBoxStyle,
+    MessageContentContainerBoxStyle, MessageInputContainerTextAreaAutosizeStyle,
     SendButtonContainerButtonStyle, SendButtonIconContainerIconButtonStyle
 } from "./SendMessageBox.styles.js";
 import theme from "../../../index.theme.js";
@@ -70,26 +70,20 @@ const SendMessageBox = () => {
                     <Box  sx={EmojiButtonContainerBoxStyle}>
                         <StyledFontAwesomeIcon icon={faFaceSmile}  sx={EmojiButtonIconContainerIconButtonStyle}/>
                     </Box>
-                    <textarea
-                        style={{
-                            height: '2rem',
-                            fontSize: '1.2rem',
-                            width: '100%',
-                            padding: '0.5rem',
-                            outline: 'none',
-                            border: 'none',
-                            fontFamily: 'system-ui',
-                            overflowWrap: 'break-word',
-                            resize: 'none',
-                            overflow: 'hidden'
-                        }}
+                    <Input type={"text"}
+                        sx={MessageInputContainerTextAreaAutosizeStyle}
                         placeholder="Write your message here..."
                         value={messageText}
+                       disableUnderline={true}
                         onChange={handleMessageTextChange}
                         onKeyDown={handleKeyDown}
+                       margin="dense"
+                       multiline
+                       maxRows={3}
+
                     />
                     <IconButton
-                        sx={{...sendingMessageMarker(isSendingMessage)}}>
+                        sx={{...sendingMessageMarker(isSendingMessage), flexAlign: 'flex-end' }}>
                         <FontAwesomeIcon
                             icon={faSpinner}
                             style={{animation: isSendingMessage ? {spin}+' 1s linear infinite' : ''}}/>

--- a/src/components/Chat/MainWindow/SendMessageBox.styles.js
+++ b/src/components/Chat/MainWindow/SendMessageBox.styles.js
@@ -8,6 +8,7 @@ export const MessageBoxContainerBoxStyle = {
     gap: '2rem',
     height: 'fit-content',
     marginTop: '1rem',
+
 }
 export const MessageContentContainerBoxStyle = {
     position: 'relative',
@@ -19,16 +20,19 @@ export const MessageContentContainerBoxStyle = {
     gap: '1rem',
     height: 'fit-content',
     boxShadow: '1px 1px 5px 0px rgba(0, 0, 0, 0.3)',
-    minWidth: '30rem',
+
+
+
 }
 export const EmojiButtonContainerBoxStyle = {
 
     borderRadius: '50%',
     backgroundColor: '#ffffff',
     fontSize: '1.5rem',
+    paddingLeft: '0.5rem',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
     cursor: 'pointer',
 }
 export const EmojiButtonIconContainerIconButtonStyle = {
@@ -36,14 +40,21 @@ export const EmojiButtonIconContainerIconButtonStyle = {
     opacity: 0.7,
 }
 export const MessageInputContainerTextAreaAutosizeStyle = {
-    backgroundColor: '#000000',
+    minWidth: '250px',
+    width: '30vw',
+    minHeight: '2.5rem',
+    height: 'fit-content',
+    overflow: 'auto',
     fontSize: '1.2rem',
     padding: '0.5rem',
     outline: 'none',
     border: 'none',
     fontFamily: 'system-ui',
-    overflowWrap: 'break-word',
-    overflow: 'hidden',
+    boxSizing: 'border-box',
+    resize: 'none',
+    flexGrow: 1,
+    textAlign: 'top',
+
 
 }
 export const IsSendingMessageIconVisibleContainerIconButtonStyle = {

--- a/src/components/Chat/SidePanel/ChatBox.jsx
+++ b/src/components/Chat/SidePanel/ChatBox.jsx
@@ -34,21 +34,23 @@ const ChatBox = (peerName) => {
 
     const trimPeerName = (completePeerName) => {
         // Split the string at the colon to separate the part before and after
-        if (localStorage.getItem(peerName.peerName.toString()) !== null){
-            let name = localStorage.getItem(peerName.peerName.toString())
-            setTrimmedPeerName(name)
+        try{
+            let contacts = JSON.parse(localStorage.getItem("Contacts"));
+            if (contacts[peerName.peerName] !== null && contacts[peerName.peerName] !== "" && contacts[peerName.peerName] !== undefined){
+                let name = contacts[peerName.peerName];
+                setTrimmedPeerName(name)
+            }
         }
-        else {
+        catch(error){
+            console.log(error);
             let parts = completePeerName.peerName.split(':');
             let firstPart = parts[0];
             let secondPart = parts[1];
             let start = secondPart.slice(0, 6);
             let end = secondPart.slice(-6);
             setTrimmedPeerName(firstPart + ":" + start + "..." + end)
+
         }
-
-
-
     }
     useEffect(() => {
         trimPeerName(peerName);

--- a/src/components/Chat/SidePanel/ChatBox.jsx
+++ b/src/components/Chat/SidePanel/ChatBox.jsx
@@ -34,16 +34,26 @@ const ChatBox = (peerName) => {
 
     const trimPeerName = (completePeerName) => {
         // Split the string at the colon to separate the part before and after
-        let parts = completePeerName.peerName.split(':');
-        let firstPart = parts[0];
-        let secondPart = parts[1];
-        let start = secondPart.slice(0, 6);
-        let end = secondPart.slice(-6);
-        setTrimmedPeerName(firstPart + ":" + start + "..." + end)
+        if (localStorage.getItem(peerName.peerName.toString()) !== null){
+            let name = localStorage.getItem(peerName.peerName.toString())
+            setTrimmedPeerName(name)
+        }
+        else {
+            let parts = completePeerName.peerName.split(':');
+            let firstPart = parts[0];
+            let secondPart = parts[1];
+            let start = secondPart.slice(0, 6);
+            let end = secondPart.slice(-6);
+            setTrimmedPeerName(firstPart + ":" + start + "..." + end)
+        }
+
+
+
     }
     useEffect(() => {
         trimPeerName(peerName);
         createProfileImage(peerName);
+
     }, [peerName])
 
 
@@ -52,6 +62,9 @@ const ChatBox = (peerName) => {
             return SelectedChatBoxContainerBoxStyle
         }
     }
+
+
+
     return(
 
         <Box

--- a/src/components/Chat/SidePanel/ChatBox.styles.js
+++ b/src/components/Chat/SidePanel/ChatBox.styles.js
@@ -4,6 +4,7 @@ export const ChatBoxContainerBoxStyle = {
     alignItems: "center",
     gap: '1rem',
     width: '100%',
+
     minHeight: '4rem',
     cursor: 'pointer',
     transition: 'all .3s ease',
@@ -24,8 +25,6 @@ export const ChatImageSmallScreenContainerImageListItemStyle = {
     objectFit: 'cover'
 }
 export const ChatImageContainerBoxStyle = {
-    width: '2rem',
-    height: '2rem',
     flexBasis: '15%',
     display: 'flex',
     alignItems: 'center',
@@ -33,7 +32,7 @@ export const ChatImageContainerBoxStyle = {
 }
 export const ChatImageBigScreenContainerImageListItemStyle = {
     borderRadius: '50%',
-    maxWidth: '2rem',
+    width: '3rem',
     objectFit: 'cover'
 }
 export const ChatDetailsContainerBoxStyle = {

--- a/src/components/Chat/SidePanel/Header.jsx
+++ b/src/components/Chat/SidePanel/Header.jsx
@@ -92,7 +92,9 @@ const Header = () => {
                                 backgroundColor: 'rgba(0, 0, 0, 0.25)',
                             },
                         },
+
                     }}
+
                     sx={ModalContainerDialogStyle}>
                 <Box  sx={ModalContentContainerBoxStyle} ref={modalRef}>
                     <DialogTitle sx={ModalTitleContainerDialogTitleStyle}>Start a new conversation</DialogTitle>
@@ -105,6 +107,7 @@ const Header = () => {
                             onChange={(event) => setNewPeerAddress(event.target.value)}
                             placeholder="Enter new peer address"
                             sx={ModalInputContainerInputStyle}
+                            disableUnderline={true}
                         />
                     </Box>
                     <Box>
@@ -115,13 +118,8 @@ const Header = () => {
                             value={messageArea}
                             onChange={(event) => setMessageArea(event.target.value)}
                             placeholder="Write your message"
-                            style={{
-                                width: '100%',
-                                padding: '10px',
-                                marginBottom: '15px',
-                                border: '1px solid #ccc',
-                                borderRadius: '4px',
-                            }}
+                            disableUnderline={true}
+                            sx={ModalInputContainerInputStyle}
 
                         />
                     </Box>

--- a/src/components/Chat/SidePanel/Header.styles.js
+++ b/src/components/Chat/SidePanel/Header.styles.js
@@ -65,10 +65,14 @@ export const ModalContainerDialogStyle = {
     left: '50%',
     transform: 'translate(-50%, -50%)',
     zIndex: 1300,
+    '& .MuiPaper-root': {
+        width: '70%',
+        maxWidth: '80ch',
 
-}
+}}
 export const ModalContentContainerBoxStyle = {
     padding: '40px',
+
 
 }
 export const ModalTitleContainerDialogTitleStyle = {

--- a/src/components/Contacts/Contact.jsx
+++ b/src/components/Contacts/Contact.jsx
@@ -15,7 +15,7 @@ import {
 } from "../Chat/SidePanel/Header.styles.js";
 import { useState} from "react";
 
-const Contact = ({ name, address }) => {
+const Contact = ({ name, address}) => {
     const [openModal, setOpenModal] = useState(false);
     const [newAlias, setNewAlias] = useState("");
     const [currentName, setCurrentName] = useState(name);
@@ -57,6 +57,30 @@ const Contact = ({ name, address }) => {
         closeModalHandler();
     }
 
+     const removeAliasHandler = () => {
+         const confirmation = window.confirm("Sei sicuro di voler rimuovere questo contatto?");
+         if (confirmation) {
+
+             let contacts = JSON.parse(localStorage.getItem("Contacts"));
+
+
+
+             if (!contacts) {
+                 console.log("Nessun contatto salvato.");
+                 return;
+             }
+
+
+             if (contacts[address]) {
+                 delete contacts[currentAddress];
+                 localStorage.setItem("Contacts", JSON.stringify(contacts));
+                 console.log(`Contatto con l'indirizzo ${address} rimosso.`);
+                 window.location.reload();
+             } else {
+                 console.log(`L'indirizzo ${address} non esiste.`);
+             }
+        }
+    }
 
     return (
         <>
@@ -87,6 +111,7 @@ const Contact = ({ name, address }) => {
                     Edit
                 </Button>
                 <Button sx={{ ...BothActionsContainerButtonStyle, ...CancelButtonContainerButtonStyle }}
+                        onClick={removeAliasHandler}
                         variant="outlined"
                         size="small"
                         color="error">

--- a/src/components/Contacts/Contact.jsx
+++ b/src/components/Contacts/Contact.jsx
@@ -1,17 +1,68 @@
 import ListItem from "@mui/material/ListItem";
 import Box from "@mui/material/Box";
-import { Button, Typography } from "@mui/material";
+import {Button, Dialog, DialogTitle, Input, Typography} from "@mui/material";
 import {
     BothActionsContainerButtonStyle, CancelButtonContainerButtonStyle, ConfirmButtonContainerButtonStyle,
     ListItemShellContainerBoxStyle,
 } from "./Contact.styles.js";
 import {AddressContainerTypographyStyle} from "./ContactList.styles.js";
+import {
+    CloseButtonContainerButtonStyle,
+    ModalButtonsContainerBoxStyle,
+    ModalContainerDialogStyle,
+    ModalContentContainerBoxStyle, ModalInputContainerInputStyle,
+    ModalTitleContainerDialogTitleStyle, SendButtonContainerButtonStyle
+} from "../Chat/SidePanel/Header.styles.js";
+import { useState} from "react";
 
 const Contact = ({ name, address }) => {
+    const [openModal, setOpenModal] = useState(false);
+    const [newAlias, setNewAlias] = useState("");
+    const [currentName, setCurrentName] = useState(name);
+    const [currentAddress] = useState(address);
+
+
+
+    const openModalHandler = () => {
+        setOpenModal(true);
+    };
+    const closeModalHandler = () => {
+        setOpenModal(false);
+        setNewAlias("");
+
+    };
+    const saveAliasHandler = () => {
+        if (newAlias) {
+            try {
+                let contacts = JSON.parse(localStorage.getItem("Contacts"));
+                if (contacts) {
+                    contacts[address] = newAlias;
+                } else {
+                    contacts = { [address]: newAlias };
+                }
+
+                localStorage.setItem('Contacts', JSON.stringify(contacts));
+
+                setCurrentName(newAlias)
+                setNewAlias("");
+
+            } catch (error) {
+                console.error("Errore durante il salvataggio dei contatti:", error);
+            }
+        } else {
+            alert("Alias can't be empty");
+        }
+
+
+        closeModalHandler();
+    }
+
+
     return (
+        <>
         <ListItem sx={ListItemShellContainerBoxStyle}>
             <Typography component="span" >
-                {name}
+                {currentName}
             </Typography>
             <Typography
                 component="span"
@@ -20,7 +71,7 @@ const Contact = ({ name, address }) => {
                     justifyContent: "flex-start",
                 }}
             >
-                {address}
+                {currentAddress}
             </Typography>
             <Box sx={{    display: "flex",
                 gap: 1,
@@ -29,14 +80,75 @@ const Contact = ({ name, address }) => {
                 justifyContent: "center",
                 alignItems: "center",  }}>
 
-                <Button sx={{ ...BothActionsContainerButtonStyle, ...ConfirmButtonContainerButtonStyle }} variant="outlined" size="small">
+                <Button onClick={openModalHandler}
+                        sx={{ ...BothActionsContainerButtonStyle, ...ConfirmButtonContainerButtonStyle }}
+                        variant="outlined"
+                        size="small">
                     Edit
                 </Button>
-                <Button sx={{ ...BothActionsContainerButtonStyle, ...CancelButtonContainerButtonStyle }} variant="outlined" size="small" color="error">
+                <Button sx={{ ...BothActionsContainerButtonStyle, ...CancelButtonContainerButtonStyle }}
+                        variant="outlined"
+                        size="small"
+                        color="error">
                     Delete
                 </Button>
             </Box>
         </ListItem>
+
+            <Dialog open={openModal}
+                    onClose={closeModalHandler}
+                    slotProps={{
+                        backdrop: {
+                            sx: {
+                                backgroundColor: 'rgba(0, 0, 0, 0.25)',
+                            },
+                        },
+
+                    }}
+
+                    sx={ModalContainerDialogStyle}>
+                <Box  sx={ModalContentContainerBoxStyle} >
+                    <DialogTitle sx={ModalTitleContainerDialogTitleStyle}>Save Address</DialogTitle>
+
+                    <Box>
+                        <label>Address</label>
+                        <Input
+                            type="text"
+                            value={address}
+                            disabled={true}
+                            sx={ModalInputContainerInputStyle}
+                            disableUnderline={true}
+                        />
+                    </Box>
+                    <Box>
+                        <label>New Alias:</label>
+                        <Input
+                            type="text"
+                            id="newAlias"
+                            value={newAlias}
+                            onChange={(event) => setNewAlias(event.target.value)}
+                            placeholder="Enter Alias for the address"
+                            sx={ModalInputContainerInputStyle}
+                            disableUnderline={true}
+                        />
+                    </Box>
+
+                    <Box sx={ModalButtonsContainerBoxStyle} >
+                        <Button
+                            onClick={() => {saveAliasHandler()}}
+
+                            sx={SendButtonContainerButtonStyle}>
+
+                            Save
+                        </Button>
+                        <Button onClick={closeModalHandler}
+                                sx={CloseButtonContainerButtonStyle}>
+                            Cancel
+                        </Button>
+                    </Box>
+                </Box>
+            </Dialog>
+        </>
     );
 };
 

--- a/src/components/Contacts/Contact.jsx
+++ b/src/components/Contacts/Contact.jsx
@@ -5,7 +5,7 @@ import {
     BothActionsContainerButtonStyle, CancelButtonContainerButtonStyle, ConfirmButtonContainerButtonStyle,
     ListItemShellContainerBoxStyle,
 } from "./Contact.styles.js";
-import {AddressContainerTypographyStyle} from "./ContactList.styles.js";
+import {AddressContainerTypographyStyle, ButtonContainerBoxStyle} from "./ContactList.styles.js";
 import {
     CloseButtonContainerButtonStyle,
     ModalButtonsContainerBoxStyle,
@@ -97,12 +97,7 @@ const Contact = ({ name, address}) => {
             >
                 {currentAddress}
             </Typography>
-            <Box sx={{    display: "flex",
-                gap: 1,
-                alignSelf: "center",
-                width: "100%",
-                justifyContent: "center",
-                alignItems: "center",  }}>
+            <Box sx={ButtonContainerBoxStyle}>
 
                 <Button onClick={openModalHandler}
                         sx={{ ...BothActionsContainerButtonStyle, ...ConfirmButtonContainerButtonStyle }}

--- a/src/components/Contacts/Contact.jsx
+++ b/src/components/Contacts/Contact.jsx
@@ -1,0 +1,42 @@
+import ListItem from "@mui/material/ListItem";
+import Box from "@mui/material/Box";
+import { Button, Typography } from "@mui/material";
+import {
+    AddressContainerTypographyStyle,
+    BothActionsContainerButtonStyle, CancelButtonContainerButtonStyle, ConfirmButtonContainerButtonStyle,
+    ListItemShellContainerBoxStyle
+} from "./Contact.styles.js";
+
+
+
+const Contact = ({ name, address }) => {
+    return (
+        <ListItem sx={ListItemShellContainerBoxStyle}>
+            <Typography component="span" sx={{ flex: "1 0 auto", textAlign: "left" }}>
+                {name}
+            </Typography>
+            <Typography
+                component="span"
+                sx={{
+                    ...AddressContainerTypographyStyle,
+                    justifyContent: "flex-start",
+                }}
+            >
+                {address}
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1 }}>
+                {/* Puoi aggiungere qui i bottoni per le azioni */}
+                <Button sx={{ ...BothActionsContainerButtonStyle,
+                    ...ConfirmButtonContainerButtonStyle}} variant="outlined" size="small">
+                    Edit
+                </Button>
+                <Button sx={{ ...BothActionsContainerButtonStyle,
+                    ...CancelButtonContainerButtonStyle}}  variant="outlined" size="small" color="error">
+                    Delete
+                </Button>
+            </Box>
+        </ListItem>
+    );
+};
+
+export default Contact;

--- a/src/components/Contacts/Contact.jsx
+++ b/src/components/Contacts/Contact.jsx
@@ -2,17 +2,15 @@ import ListItem from "@mui/material/ListItem";
 import Box from "@mui/material/Box";
 import { Button, Typography } from "@mui/material";
 import {
-    AddressContainerTypographyStyle,
     BothActionsContainerButtonStyle, CancelButtonContainerButtonStyle, ConfirmButtonContainerButtonStyle,
-    ListItemShellContainerBoxStyle
+    ListItemShellContainerBoxStyle,
 } from "./Contact.styles.js";
-
-
+import {AddressContainerTypographyStyle} from "./ContactList.styles.js";
 
 const Contact = ({ name, address }) => {
     return (
         <ListItem sx={ListItemShellContainerBoxStyle}>
-            <Typography component="span" sx={{ flex: "1 0 auto", textAlign: "left" }}>
+            <Typography component="span" >
                 {name}
             </Typography>
             <Typography
@@ -24,14 +22,17 @@ const Contact = ({ name, address }) => {
             >
                 {address}
             </Typography>
-            <Box sx={{ display: "flex", gap: 1 }}>
-                {/* Puoi aggiungere qui i bottoni per le azioni */}
-                <Button sx={{ ...BothActionsContainerButtonStyle,
-                    ...ConfirmButtonContainerButtonStyle}} variant="outlined" size="small">
+            <Box sx={{    display: "flex",
+                gap: 1,
+                alignSelf: "center",
+                width: "100%",
+                justifyContent: "center",
+                alignItems: "center",  }}>
+
+                <Button sx={{ ...BothActionsContainerButtonStyle, ...ConfirmButtonContainerButtonStyle }} variant="outlined" size="small">
                     Edit
                 </Button>
-                <Button sx={{ ...BothActionsContainerButtonStyle,
-                    ...CancelButtonContainerButtonStyle}}  variant="outlined" size="small" color="error">
+                <Button sx={{ ...BothActionsContainerButtonStyle, ...CancelButtonContainerButtonStyle }} variant="outlined" size="small" color="error">
                     Delete
                 </Button>
             </Box>

--- a/src/components/Contacts/Contact.styles.js
+++ b/src/components/Contacts/Contact.styles.js
@@ -1,21 +1,13 @@
 export const ListItemShellContainerBoxStyle = {
-    display: "flex",
-    justifyContent: "space-between",
+    display: "grid",
+    gridTemplateColumns: "1fr 2fr 1fr",
+    gap: "16px",
     width: "100%",
-    maxWidth: "70rem",
+    padding: "8px",
     border: "1px solid grey",
-    borderRadius: 5,
-};
-export const TypographyContainerSpanStyle = {
-    display: "inline-block",
-    flex: "1 0 auto",
-    textAlign: "left",
+    borderRadius: "5px",
 };
 
-export const AddressContainerTypographyStyle = {
-    ...TypographyContainerSpanStyle,
-    justifyContent: "flex-start",
-};
 
 export const BothActionsContainerButtonStyle = {
     display: 'flex',
@@ -34,7 +26,7 @@ export const ConfirmButtonContainerButtonStyle = {
     width: '70px',
 }
 export const CancelButtonContainerButtonStyle = {
-    padding: '10px 20px',
+    padding: '5px 10px',
     cursor: 'pointer',
     border: 'none',
     borderRadius: '4px',

--- a/src/components/Contacts/Contact.styles.js
+++ b/src/components/Contacts/Contact.styles.js
@@ -1,0 +1,47 @@
+export const ListItemShellContainerBoxStyle = {
+    display: "flex",
+    justifyContent: "space-between",
+    width: "100%",
+    maxWidth: "70rem",
+    border: "1px solid grey",
+    borderRadius: 5,
+};
+export const TypographyContainerSpanStyle = {
+    display: "inline-block",
+    flex: "1 0 auto",
+    textAlign: "left",
+};
+
+export const AddressContainerTypographyStyle = {
+    ...TypographyContainerSpanStyle,
+    justifyContent: "flex-start",
+};
+
+export const BothActionsContainerButtonStyle = {
+    display: 'flex',
+    gap: '10px',
+}
+export const ConfirmButtonContainerButtonStyle = {
+    padding: '5px 10px',
+    cursor: 'pointer',
+    border: 'none',
+    borderRadius: '4px',
+    backgroundColor: '#4CAF50',
+    color: 'white',
+    '&:hover': {
+        backgroundColor: '#45a049',
+    },
+    width: '70px',
+}
+export const CancelButtonContainerButtonStyle = {
+    padding: '10px 20px',
+    cursor: 'pointer',
+    border: 'none',
+    borderRadius: '4px',
+    backgroundColor: '#f44336',
+    color: 'white',
+    '&:hover': {
+        backgroundColor: '#e53935',
+    },
+    width: '70px'
+}

--- a/src/components/Contacts/ContactList.jsx
+++ b/src/components/Contacts/ContactList.jsx
@@ -10,9 +10,11 @@ import {
     ActionContainerTypographyStyle,
     ContactContainerListStyle
 } from "./ContactList.styles.js";
+import {useState} from "react";
 
 const ContactList = () => {
-    const contacts = JSON.parse(localStorage.getItem("Contacts")) || {};
+    const [contacts, setContacts] = useState(JSON.parse(localStorage.getItem("Contacts")) || {});
+
 
     return (
         <Box sx={ShellContainerBoxStyle}>

--- a/src/components/Contacts/ContactList.jsx
+++ b/src/components/Contacts/ContactList.jsx
@@ -1,0 +1,43 @@
+import List from "@mui/material/List";
+import Box from "@mui/material/Box";
+import Contact from "./Contact.jsx";
+import { Typography } from "@mui/material";
+import {
+    ActionContainerTypographyStyle,
+    AddressContainerTypographyStyle, ContactContainerListStyle,
+    ShellContainerBoxStyle,
+    TableHeaderContainerBoxStyle,
+    TypographyContainerSpanStyle
+} from "./ContactList.styles.js";
+
+const ContactList = () => {
+    const contacts = JSON.parse(localStorage.getItem("Contacts")) || {};
+
+    return (
+        <Box sx={ShellContainerBoxStyle}>
+            <Box sx={TableHeaderContainerBoxStyle}>
+                <Typography sx={TypographyContainerSpanStyle} component="span">
+                    Name:
+                </Typography>
+                <Typography
+                    sx={{ ...TypographyContainerSpanStyle, ...AddressContainerTypographyStyle }}
+                    component="span"
+                >
+                    Address:
+                </Typography>
+                <Typography sx={{...TypographyContainerSpanStyle, ...ActionContainerTypographyStyle}} component="span">
+                    Actions:
+                </Typography>
+            </Box>
+            <List
+                sx={ContactContainerListStyle}
+            >
+                {Object.entries(contacts).map(([address, name]) => (
+                    <Contact key={address} name={name} address={address} />
+                ))}
+            </List>
+        </Box>
+    );
+};
+
+export default ContactList;

--- a/src/components/Contacts/ContactList.jsx
+++ b/src/components/Contacts/ContactList.jsx
@@ -3,11 +3,12 @@ import Box from "@mui/material/Box";
 import Contact from "./Contact.jsx";
 import { Typography } from "@mui/material";
 import {
-    ActionContainerTypographyStyle,
-    AddressContainerTypographyStyle, ContactContainerListStyle,
     ShellContainerBoxStyle,
     TableHeaderContainerBoxStyle,
-    TypographyContainerSpanStyle
+    TypographyContainerSpanStyle,
+    AddressContainerTypographyStyle,
+    ActionContainerTypographyStyle,
+    ContactContainerListStyle
 } from "./ContactList.styles.js";
 
 const ContactList = () => {
@@ -17,21 +18,19 @@ const ContactList = () => {
         <Box sx={ShellContainerBoxStyle}>
             <Box sx={TableHeaderContainerBoxStyle}>
                 <Typography sx={TypographyContainerSpanStyle} component="span">
-                    Name:
+                    Name
                 </Typography>
                 <Typography
                     sx={{ ...TypographyContainerSpanStyle, ...AddressContainerTypographyStyle }}
                     component="span"
                 >
-                    Address:
+                    Address
                 </Typography>
                 <Typography sx={{...TypographyContainerSpanStyle, ...ActionContainerTypographyStyle}} component="span">
-                    Actions:
+                    Actions
                 </Typography>
             </Box>
-            <List
-                sx={ContactContainerListStyle}
-            >
+            <List sx={ContactContainerListStyle}>
                 {Object.entries(contacts).map(([address, name]) => (
                     <Contact key={address} name={name} address={address} />
                 ))}

--- a/src/components/Contacts/ContactList.styles.js
+++ b/src/components/Contacts/ContactList.styles.js
@@ -27,6 +27,14 @@ export const AddressContainerTypographyStyle = {
     textAlign: "left",
 
 };
+export const ButtonContainerBoxStyle = {
+    display: "flex",
+    gap: 1,
+    alignSelf: "center",
+    width: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+}
 
 export const ActionContainerTypographyStyle = {
     textAlign: "center",

--- a/src/components/Contacts/ContactList.styles.js
+++ b/src/components/Contacts/ContactList.styles.js
@@ -6,35 +6,37 @@ export const ShellContainerBoxStyle = {
 };
 
 export const TableHeaderContainerBoxStyle = {
-    display: "flex",
-    justifyContent: "space-between",
+    display: "grid",
+    gridTemplateColumns: "1fr 2fr 1fr",
+    gap: "16px",
+    marginBottom: 2,
+    fontWeight: "bold",
+    padding: "0 8px",
     width: "100%",
     maxWidth: "70rem",
-    gap: 2,
-    marginBottom: 2,
+    backgroundColor: "#f4f4f4"
 };
 
 export const TypographyContainerSpanStyle = {
     display: "inline-block",
-    flex: "1 0 auto",
     textAlign: "left",
 };
 
 export const AddressContainerTypographyStyle = {
     ...TypographyContainerSpanStyle,
-    justifyContent: "flex-start",
-    textAlign: "center",
+    textAlign: "left",
+
 };
+
 export const ActionContainerTypographyStyle = {
     textAlign: "center",
-    marginLeft: '11rem',
-}
+
+};
+
 export const ContactContainerListStyle = {
-    width: "100%",
-    maxWidth: "70rem",
     display: "flex",
     flexDirection: "column",
-    gap: 2,
-
-
-}
+    gap: "16px",
+    width: "100%",
+    maxWidth: "70rem",
+    marginTop: "8px", }

--- a/src/components/Contacts/ContactList.styles.js
+++ b/src/components/Contacts/ContactList.styles.js
@@ -1,0 +1,40 @@
+export const ShellContainerBoxStyle = {
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+};
+
+export const TableHeaderContainerBoxStyle = {
+    display: "flex",
+    justifyContent: "space-between",
+    width: "100%",
+    maxWidth: "70rem",
+    gap: 2,
+    marginBottom: 2,
+};
+
+export const TypographyContainerSpanStyle = {
+    display: "inline-block",
+    flex: "1 0 auto",
+    textAlign: "left",
+};
+
+export const AddressContainerTypographyStyle = {
+    ...TypographyContainerSpanStyle,
+    justifyContent: "flex-start",
+    textAlign: "center",
+};
+export const ActionContainerTypographyStyle = {
+    textAlign: "center",
+    marginLeft: '11rem',
+}
+export const ContactContainerListStyle = {
+    width: "100%",
+    maxWidth: "70rem",
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+
+
+}

--- a/src/components/Contacts/Root.jsx
+++ b/src/components/Contacts/Root.jsx
@@ -1,0 +1,22 @@
+
+import Box from "@mui/material/Box";
+import {Typography} from "@mui/material";
+import {RootContainerBoxStyle} from "./Root.styles.js";
+import ContactList from "./ContactList.jsx";
+
+
+
+const Root = () => {
+
+
+    return (
+
+        <Box sx={RootContainerBoxStyle}>
+            <Typography variant={'h3'} >Contacts view</Typography>
+            <ContactList/>
+        </Box>
+
+    )
+}
+
+export default Root;

--- a/src/components/Contacts/Root.styles.js
+++ b/src/components/Contacts/Root.styles.js
@@ -1,0 +1,9 @@
+export const RootContainerBoxStyle = {
+    width: '100%',
+    height: '98vh',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    background: 'linear-gradient(45deg, #ffffff 0%, #6dc1b4 100%)'
+}

--- a/src/views/ContactsView.jsx
+++ b/src/views/ContactsView.jsx
@@ -2,7 +2,8 @@ import { useContext } from "react";
 import { GeneralContextProvider} from "../components/ContextProviders/GeneralContextProvider";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars } from '@fortawesome/free-solid-svg-icons'
-import { Button } from "@mui/material";
+import {Button,} from "@mui/material";
+import Root from "../components/Contacts/Root.jsx";
 
 const ContactsView = () => {
     const { updateOpenMenuDrawer} = useContext(GeneralContextProvider);
@@ -11,9 +12,8 @@ const ContactsView = () => {
             <Button sx={{ height: 30}} onClick={() => updateOpenMenuDrawer(true)}>
                 <FontAwesomeIcon icon={faBars} />
             </Button>
-            <div>
-                <h3>Contacts view</h3>
-            </div>
+                <Root></Root>
+
             
         </>
     );


### PR DESCRIPTION
- Completed SendMessage input style, now it gets its style from the styles.js file, it has an adjustable lenght according with screen size and lastly it creates new lines when you reach the end of the input container (max 3 lines, for more you get a scrollbar)

-Added custom changes for the new Peer modal, now you can read the whole kaspatest address in the input box.

- Added ability to set aliases directly from chat by pressing the 3 dots in the top right corner

- Added Page Contacts list and completed its functionality, now from there you can either rename a contact or delete 
